### PR TITLE
Feature/alternate ddp connection

### DIFF
--- a/examples/chat/chat.js
+++ b/examples/chat/chat.js
@@ -1,4 +1,4 @@
-const streamer  = new Meteor.Streamer('chat');
+const streamer = new Meteor.Streamer('chat');
 
 if(Meteor.isClient) {
 	const messages = new Mongo.Collection(null);

--- a/examples/chat/chat.js
+++ b/examples/chat/chat.js
@@ -1,4 +1,4 @@
-const streamer = new Meteor.Streamer('chat');
+const streamer  = new Meteor.Streamer('chat');
 
 if(Meteor.isClient) {
 	const messages = new Mongo.Collection(null);

--- a/packages/rocketchat-streamer/client/client.js
+++ b/packages/rocketchat-streamer/client/client.js
@@ -43,12 +43,12 @@ class StreamerCentral extends EV {
 Meteor.StreamerCentral = new StreamerCentral;
 
 Meteor.Streamer = class Streamer extends EV {
-	constructor(name, {useCollection = false, ddpConnection = undefined } = {}) {
+	constructor(name, {useCollection = false, ddpConnection = Meteor.connection } = {}) {
 		if (Meteor.StreamerCentral.instances[name]) {
 			console.warn('Streamer instance already exists:', name);
 			return Meteor.StreamerCentral.instances[name];
 		}
-		Meteor.StreamerCentral.setupDdpConnection(name, ddpConnection || Meteor.connection);
+		Meteor.StreamerCentral.setupDdpConnection(name, ddpConnection);
 
 		super();
 


### PR DESCRIPTION
see #4

* allow a ddp connection object to be provided to Streamer constructor to override default ddp connection (`Meteor.connection)`
* changed StreamerCentral to store all ddp connections, and setup listeners for each