### PR TITLE
Add check for options parameter

### DIFF
--- a/packages/rocketchat-streamer/server/server.js
+++ b/packages/rocketchat-streamer/server/server.js
@@ -262,6 +262,10 @@ Meteor.Streamer = class Streamer extends EV {
 		const stream = this;
 		Meteor.publish(this.subscriptionName, function(eventName, options) {
 			check(eventName, String);
+			check(options, Match.OneOf(Boolean, {
+				useCollection: Boolean,
+				args: Array,
+			}));
 
 			let useCollection, args = [];
 


### PR DESCRIPTION
Before Meteor v1.6.1, the missing check for the options parameter didn't throw an error if the app is using the `audit-argument-checks` package (that was a bug in meteor).
With `audit-argument-checks` package, `rocketchat:streamer` doesn't work with Meteor v1.6.1